### PR TITLE
Add new dark-themed control hub

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,36 +1,45 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, redirect, url_for
 from neopixel_controller import fill, off, set_brightness, run_animation
 
-app = Flask(__name__, template_folder='../frontend/templates',
-                      static_folder='../frontend/static')
+app = Flask(
+    __name__,
+    template_folder='../frontend/templates',
+    static_folder='../frontend/static'
+)
+
+
+def get_fake_status():
+    return {
+        'temperature': 36.6,
+        'suit_temperature': 31.4,
+        'voltage': 12.3,
+        'cooling_status': 'OFF',
+        'fans': 'IDLE',
+    }
 
 @app.route('/')
-def index():
-    return render_template('index.html')
+def home():
+    return render_template('v2/home.html')
+
+@app.route('/light')
+def light():
+    return render_template('v2/light.html')
 
 @app.route('/effects')
 def effects():
-    return render_template('effects.html')
-
-@app.route('/fans')
-def fans():
-    return render_template('fans.html')
-
-@app.route('/leds')
-def leds():
-    return render_template('leds.html')
+    return redirect(url_for('light'))
 
 @app.route('/cooling')
 def cooling():
-    return render_template('cooling.html')
+    return render_template('v2/cooling.html')
 
-@app.route('/pump')
-def pump():
-    return render_template('pump.html')
+@app.route('/ventilation')
+def ventilation():
+    return render_template('v2/ventilation.html')
 
 @app.route('/monitor')
 def monitor():
-    return render_template('monitor.html')
+    return render_template('v2/monitor.html')
 
 @app.post('/api/color')
 def api_color():
@@ -57,6 +66,11 @@ def api_animation():
     name = data.get('name')
     run_animation(name)
     return jsonify(status='ok', animation=name)
+
+
+@app.get('/api/status')
+def api_status():
+    return jsonify(get_fake_status())
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=False)

--- a/frontend/static/light.js
+++ b/frontend/static/light.js
@@ -1,0 +1,40 @@
+const picker = document.getElementById('picker');
+const brightnessSlider = document.getElementById('brightness');
+
+function setColor() {
+  const hex = picker.value;
+  const rgb = [
+    parseInt(hex.substr(1,2),16),
+    parseInt(hex.substr(3,2),16),
+    parseInt(hex.substr(5,2),16)
+  ];
+  fetch('/api/color', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({r: rgb[0], g: rgb[1], b: rgb[2]})
+  });
+}
+
+function turnOff() {
+  fetch('/api/off', {method:'POST'});
+}
+
+document.getElementById('set')?.addEventListener('click', setColor);
+document.getElementById('off')?.addEventListener('click', turnOff);
+
+brightnessSlider?.addEventListener('input', () => {
+  const val = parseFloat(brightnessSlider.value);
+  fetch('/api/brightness', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({value: val})
+  });
+});
+
+function sendAnimation(name) {
+  fetch('/api/animation', {
+    method: 'POST',
+    headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({name})
+  });
+}

--- a/frontend/static/monitor.js
+++ b/frontend/static/monitor.js
@@ -1,0 +1,11 @@
+async function fetchStatus() {
+  const resp = await fetch('/api/status');
+  const data = await resp.json();
+  document.getElementById('temperature').textContent = data.temperature;
+  document.getElementById('suit_temperature').textContent = data.suit_temperature;
+  document.getElementById('voltage').textContent = data.voltage;
+  document.getElementById('cooling_status').textContent = data.cooling_status;
+  document.getElementById('fans').textContent = data.fans;
+}
+fetchStatus();
+setInterval(fetchStatus, 3000);

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,0 +1,3 @@
+body {
+  font-family: 'Orbitron', 'Segoe UI', Tahoma, sans-serif;
+}

--- a/frontend/templates/v2/coming_soon.html
+++ b/frontend/templates/v2/coming_soon.html
@@ -1,0 +1,8 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Coming Soon{% endblock %}
+{% block content %}
+<div class="text-center py-5">
+  <div class="display-1 mb-3">🚧</div>
+  <h2>Coming soon</h2>
+</div>
+{% endblock %}

--- a/frontend/templates/v2/cooling.html
+++ b/frontend/templates/v2/cooling.html
@@ -1,0 +1,2 @@
+{% extends 'v2/coming_soon.html' %}
+{% block title %}Cooling{% endblock %}

--- a/frontend/templates/v2/home.html
+++ b/frontend/templates/v2/home.html
@@ -1,0 +1,8 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Control Hub{% endblock %}
+{% block content %}
+<div class="text-center">
+  <h1 class="display-4 mb-4">Welcome to Black Playa Mk-I</h1>
+  <p>Use the navigation menu to control suit systems.</p>
+</div>
+{% endblock %}

--- a/frontend/templates/v2/layout.html
+++ b/frontend/templates/v2/layout.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Black Playa Mk-I{% endblock %}</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="d-flex flex-column min-vh-100">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">Black Playa Mk-I</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbar">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item"><a class="nav-link" href="/light">Light</a></li>
+        <li class="nav-item"><a class="nav-link" href="/cooling">Cooling</a></li>
+        <li class="nav-item"><a class="nav-link" href="/ventilation">Ventilation</a></li>
+        <li class="nav-item"><a class="nav-link" href="/monitor">Monitor</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-5 pt-4">
+  {% block content %}{% endblock %}
+</div>
+<footer class="mt-auto text-center py-3">
+  <small>Black Playa Mk-I Control &copy; 2024</small>
+</footer>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+{% block scripts %}{% endblock %}
+</body>
+</html>

--- a/frontend/templates/v2/light.html
+++ b/frontend/templates/v2/light.html
@@ -1,0 +1,23 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Light Control{% endblock %}
+{% block content %}
+<h1 class="mb-4">Lighting</h1>
+<div class="mb-3">
+  <label for="picker" class="form-label">Color</label>
+  <input type="color" id="picker" value="#ff0000" class="form-control form-control-color" />
+  <button class="btn btn-primary mt-2" id="set">Set Color</button>
+</div>
+<div class="mb-3">
+  <label for="brightness" class="form-label">Brightness</label>
+  <input type="range" id="brightness" min="0" max="0.5" step="0.05" value="0.3" class="form-range" />
+</div>
+<div class="mb-3">
+  <button class="btn btn-primary me-2" onclick="sendAnimation('rainbow')">Rainbow</button>
+  <button class="btn btn-primary me-2" onclick="sendAnimation('pulse')">Pulse</button>
+  <button class="btn btn-primary me-2" onclick="sendAnimation('chase')">Chase</button>
+  <button class="btn btn-secondary" id="off">Off</button>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='light.js') }}"></script>
+{% endblock %}

--- a/frontend/templates/v2/monitor.html
+++ b/frontend/templates/v2/monitor.html
@@ -1,0 +1,15 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Monitor{% endblock %}
+{% block content %}
+<h1 class="mb-4">System Monitor</h1>
+<ul class="list-group" id="status">
+  <li class="list-group-item">Temperature: <span id="temperature"></span> °C</li>
+  <li class="list-group-item">Suit Temperature: <span id="suit_temperature"></span> °C</li>
+  <li class="list-group-item">Voltage: <span id="voltage"></span> V</li>
+  <li class="list-group-item">Cooling: <span id="cooling_status"></span></li>
+  <li class="list-group-item">Fans: <span id="fans"></span></li>
+</ul>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='monitor.js') }}"></script>
+{% endblock %}

--- a/frontend/templates/v2/ventilation.html
+++ b/frontend/templates/v2/ventilation.html
@@ -1,0 +1,2 @@
+{% extends 'v2/coming_soon.html' %}
+{% block title %}Ventilation{% endblock %}


### PR DESCRIPTION
## Summary
- add new dark themed layout and pages for v2 interface
- provide placeholder cooling and ventilation pages
- implement monitor page with fake status updated via AJAX
- merge color and effects controls into `/light`
- expose `/api/status` and routing changes on backend

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687e70902be483208bb08233a7f5a170