### PR TITLE
Add telemetry page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,6 +2,9 @@ from flask import Flask, render_template, request, jsonify, redirect, url_for
 from neopixel_controller import fill, off, set_brightness, run_animation
 import random
 import time
+import os
+import shutil
+import subprocess
 
 app = Flask(
     __name__,
@@ -39,6 +42,71 @@ def get_fake_status():
         _last_update = now
     return _last_status
 
+
+def read_cpu_temp():
+    """Return CPU temperature in Celsius if available."""
+    try:
+        with open('/sys/class/thermal/thermal_zone0/temp') as f:
+            return round(int(f.read().strip()) / 1000, 1)
+    except FileNotFoundError:
+        try:
+            result = subprocess.run(['vcgencmd', 'measure_temp'], capture_output=True, text=True)
+            if result.returncode == 0:
+                out = result.stdout.strip()
+                if out.startswith('temp=') and out.endswith("'C"):
+                    return float(out.replace('temp=', '').replace("'C", ''))
+        except Exception:
+            pass
+    return None
+
+
+def read_cpu_freq():
+    """Return CPU frequency in MHz if available."""
+    path = '/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq'
+    try:
+        with open(path) as f:
+            return int(int(f.read().strip()) / 1000)
+    except FileNotFoundError:
+        return None
+
+
+def read_memory():
+    """Return used and total memory in MB."""
+    try:
+        info = {}
+        with open('/proc/meminfo') as f:
+            for line in f:
+                key, value = line.split(':', 1)
+                info[key] = int(value.strip().split()[0])
+        total = info.get('MemTotal', 0) // 1024
+        available = info.get('MemAvailable', info.get('MemFree', 0)) // 1024
+        used = total - available
+        return used, total
+    except Exception:
+        return None, None
+
+
+def read_disk():
+    """Return used and total disk space in GB."""
+    usage = shutil.disk_usage('/')
+    used = usage.used // (1024 ** 3)
+    total = usage.total // (1024 ** 3)
+    return used, total
+
+
+def get_telemetry():
+    """Gather Raspberry Pi telemetry data."""
+    mem_used, mem_total = read_memory()
+    disk_used, disk_total = read_disk()
+    return {
+        'cpu_temp': read_cpu_temp(),
+        'cpu_freq': read_cpu_freq(),
+        'mem_used': mem_used,
+        'mem_total': mem_total,
+        'disk_used': disk_used,
+        'disk_total': disk_total,
+    }
+
 @app.route('/')
 def home():
     return render_template('v2/home.html')
@@ -62,6 +130,10 @@ def ventilation():
 @app.route('/monitor')
 def monitor():
     return render_template('v2/monitor.html')
+
+@app.route('/telemetry')
+def telemetry():
+    return render_template('v2/telemetry.html')
 
 @app.post('/api/color')
 def api_color():
@@ -93,6 +165,11 @@ def api_animation():
 @app.get('/api/status')
 def api_status():
     return jsonify(get_fake_status())
+
+
+@app.get('/api/telemetry')
+def api_telemetry():
+    return jsonify(get_telemetry())
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=False)

--- a/frontend/static/telemetry.js
+++ b/frontend/static/telemetry.js
@@ -1,0 +1,12 @@
+async function fetchTelemetry() {
+  const resp = await fetch('/api/telemetry');
+  const data = await resp.json();
+  document.getElementById('cpu_temp').textContent = data.cpu_temp ?? 'N/A';
+  document.getElementById('cpu_freq').textContent = data.cpu_freq ?? 'N/A';
+  document.getElementById('mem_used').textContent = data.mem_used ?? 'N/A';
+  document.getElementById('mem_total').textContent = data.mem_total ?? 'N/A';
+  document.getElementById('disk_used').textContent = data.disk_used ?? 'N/A';
+  document.getElementById('disk_total').textContent = data.disk_total ?? 'N/A';
+}
+fetchTelemetry();
+setInterval(fetchTelemetry, 1000);

--- a/frontend/templates/v2/layout.html
+++ b/frontend/templates/v2/layout.html
@@ -21,6 +21,7 @@
         <li class="nav-item"><a class="nav-link" href="/cooling">Cooling</a></li>
         <li class="nav-item"><a class="nav-link" href="/ventilation">Ventilation</a></li>
         <li class="nav-item"><a class="nav-link" href="/monitor">Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="/telemetry">Telemetry</a></li>
       </ul>
     </div>
   </div>

--- a/frontend/templates/v2/telemetry.html
+++ b/frontend/templates/v2/telemetry.html
@@ -1,0 +1,14 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Telemetry{% endblock %}
+{% block content %}
+<h1 class="mb-4">Raspberry Pi Telemetry</h1>
+<ul class="list-group">
+  <li class="list-group-item">CPU Temperature: <span id="cpu_temp"></span> °C</li>
+  <li class="list-group-item">CPU Frequency: <span id="cpu_freq"></span> MHz</li>
+  <li class="list-group-item">Memory: <span id="mem_used"></span>/<span id="mem_total"></span> MB</li>
+  <li class="list-group-item">Disk: <span id="disk_used"></span>/<span id="disk_total"></span> GB</li>
+</ul>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='telemetry.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- gather telemetry data from Raspberry Pi (cpu temp, freq, memory, disk)
- serve telemetry data from new Flask endpoints
- show telemetry page using Bootstrap layout
- link telemetry page from navigation bar

## Testing
- `python3 -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_687f7b6c5b148320b2488e93d285ad6d