### PR TITLE
Add telemetry page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,10 @@
 from flask import Flask, render_template, request, jsonify, redirect, url_for
 from neopixel_controller import fill, off, set_brightness, run_animation
+from telemetry_service import read_cpu_temp
 import random
 import time
+import os
+import shutil
 
 app = Flask(
     __name__,
@@ -39,6 +42,55 @@ def get_fake_status():
         _last_update = now
     return _last_status
 
+
+
+def read_cpu_freq():
+    """Return CPU frequency in MHz if available."""
+    path = '/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq'
+    try:
+        with open(path) as f:
+            return int(int(f.read().strip()) / 1000)
+    except FileNotFoundError:
+        return None
+
+
+def read_memory():
+    """Return used and total memory in MB."""
+    try:
+        info = {}
+        with open('/proc/meminfo') as f:
+            for line in f:
+                key, value = line.split(':', 1)
+                info[key] = int(value.strip().split()[0])
+        total = info.get('MemTotal', 0) // 1024
+        available = info.get('MemAvailable', info.get('MemFree', 0)) // 1024
+        used = total - available
+        return used, total
+    except Exception:
+        return None, None
+
+
+def read_disk():
+    """Return used and total disk space in GB."""
+    usage = shutil.disk_usage('/')
+    used = usage.used // (1024 ** 3)
+    total = usage.total // (1024 ** 3)
+    return used, total
+
+
+def get_telemetry():
+    """Gather Raspberry Pi telemetry data."""
+    mem_used, mem_total = read_memory()
+    disk_used, disk_total = read_disk()
+    return {
+        'cpu_temp': read_cpu_temp(),
+        'cpu_freq': read_cpu_freq(),
+        'mem_used': mem_used,
+        'mem_total': mem_total,
+        'disk_used': disk_used,
+        'disk_total': disk_total,
+    }
+
 @app.route('/')
 def home():
     return render_template('v2/home.html')
@@ -62,6 +114,10 @@ def ventilation():
 @app.route('/monitor')
 def monitor():
     return render_template('v2/monitor.html')
+
+@app.route('/pi-telemetry')
+def pi_telemetry():
+    return render_template('v2/pi-telemetry.html')
 
 @app.post('/api/color')
 def api_color():
@@ -93,6 +149,11 @@ def api_animation():
 @app.get('/api/status')
 def api_status():
     return jsonify(get_fake_status())
+
+
+@app.get('/api/telemetry')
+def api_telemetry():
+    return jsonify(get_telemetry())
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=False)

--- a/backend/telemetry_service.py
+++ b/backend/telemetry_service.py
@@ -1,0 +1,18 @@
+import subprocess
+
+
+def read_cpu_temp():
+    """Return CPU temperature in Celsius if available."""
+    try:
+        with open('/sys/class/thermal/thermal_zone0/temp') as f:
+            return round(int(f.read().strip()) / 1000, 1)
+    except FileNotFoundError:
+        try:
+            result = subprocess.run(['vcgencmd', 'measure_temp'], capture_output=True, text=True)
+            if result.returncode == 0:
+                out = result.stdout.strip()
+                if out.startswith('temp=') and out.endswith("'C"):
+                    return float(out.replace('temp=', '').replace("'C", ''))
+        except Exception:
+            pass
+    return None

--- a/frontend/static/pi-telemetry.js
+++ b/frontend/static/pi-telemetry.js
@@ -1,0 +1,35 @@
+const MAX_POINTS = 60;
+
+function makeChart(ctx, label, color) {
+  return new Chart(ctx, {
+    type: 'line',
+    data: { labels: [], datasets: [{ label, data: [], borderColor: color, tension: 0.1 }] },
+    options: { animation: false, responsive: true, scales: { y: { beginAtZero: true } } }
+  });
+}
+
+const cpuTempChart = makeChart(document.getElementById('cpuTempChart'), 'CPU Temp \u00B0C', 'rgb(255,99,132)');
+const cpuFreqChart = makeChart(document.getElementById('cpuFreqChart'), 'CPU Freq MHz', 'rgb(54,162,235)');
+const memChart = makeChart(document.getElementById('memChart'), 'Memory MB', 'rgb(75,192,192)');
+const diskChart = makeChart(document.getElementById('diskChart'), 'Disk GB', 'rgb(153,102,255)');
+
+function pushData(chart, value) {
+  const labels = chart.data.labels;
+  const data = chart.data.datasets[0].data;
+  labels.push('');
+  data.push(value);
+  if (labels.length > MAX_POINTS) { labels.shift(); data.shift(); }
+  chart.update();
+}
+
+async function fetchTelemetry() {
+  const resp = await fetch('/api/telemetry');
+  const data = await resp.json();
+  if (data.cpu_temp !== null) pushData(cpuTempChart, data.cpu_temp);
+  if (data.cpu_freq !== null) pushData(cpuFreqChart, data.cpu_freq);
+  if (data.mem_used !== null) pushData(memChart, data.mem_used);
+  if (data.disk_used !== null) pushData(diskChart, data.disk_used);
+}
+
+fetchTelemetry();
+setInterval(fetchTelemetry, 1000);

--- a/frontend/templates/v2/layout.html
+++ b/frontend/templates/v2/layout.html
@@ -21,6 +21,7 @@
         <li class="nav-item"><a class="nav-link" href="/cooling">Cooling</a></li>
         <li class="nav-item"><a class="nav-link" href="/ventilation">Ventilation</a></li>
         <li class="nav-item"><a class="nav-link" href="/monitor">Monitor</a></li>
+        <li class="nav-item"><a class="nav-link" href="/pi-telemetry">Pi Telemetry</a></li>
       </ul>
     </div>
   </div>

--- a/frontend/templates/v2/pi-telemetry.html
+++ b/frontend/templates/v2/pi-telemetry.html
@@ -1,0 +1,23 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Pi Telemetry{% endblock %}
+{% block content %}
+<h1 class="mb-4">Raspberry Pi Telemetry</h1>
+<div class="row g-4">
+  <div class="col-md-6">
+    <canvas id="cpuTempChart" height="200"></canvas>
+  </div>
+  <div class="col-md-6">
+    <canvas id="cpuFreqChart" height="200"></canvas>
+  </div>
+  <div class="col-md-6">
+    <canvas id="memChart" height="200"></canvas>
+  </div>
+  <div class="col-md-6">
+    <canvas id="diskChart" height="200"></canvas>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='pi-telemetry.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- rename `/telemetry` page to `/pi-telemetry`
- move CPU temperature logic to new `telemetry_service` module
- visualize Pi metrics using Chart.js graphs

## Testing
- `python3 -m py_compile backend/app.py backend/telemetry_service.py`

------
https://chatgpt.com/codex/tasks/task_e_687f7b6c5b148320b2488e93d285ad6d