### PR TITLE
Add CPU usage chart to pi telemetry page

### DIFF
--- a/frontend/static/pi-telemetry.js
+++ b/frontend/static/pi-telemetry.js
@@ -1,19 +1,29 @@
 const MAX_POINTS = 60;
 
-function makeChart(ctx, label, color) {
+function makeChart(ctx, label, color, max=null) {
+  const options = {
+    animation: false,
+    responsive: true,
+    scales: { y: { beginAtZero: true } }
+  };
+  if (max !== null) {
+    options.scales.y.max = max;
+  }
   return new Chart(ctx, {
     type: 'line',
     data: { labels: [], datasets: [{ label, data: [], borderColor: color, tension: 0.1 }] },
-    options: { animation: false, responsive: true, scales: { y: { beginAtZero: true } } }
+    options
   });
 }
 
 const cpuTempChart = makeChart(document.getElementById('cpuTempChart'), 'CPU Temp \u00B0C', 'rgb(255,99,132)');
 const cpuFreqChart = makeChart(document.getElementById('cpuFreqChart'), 'CPU Freq MHz', 'rgb(54,162,235)');
+const cpuUsageChart = makeChart(document.getElementById('cpuUsageChart'), 'CPU Usage %', 'rgb(255,205,86)', 100);
 const memChart = makeChart(document.getElementById('memChart'), 'Memory MB', 'rgb(75,192,192)');
 const diskChart = makeChart(document.getElementById('diskChart'), 'Disk GB', 'rgb(153,102,255)');
 const cpuTempValue = document.getElementById('cpuTempValue');
 const cpuFreqValue = document.getElementById('cpuFreqValue');
+const cpuUsageValue = document.getElementById('cpuUsageValue');
 const memValue = document.getElementById('memValue');
 const diskValue = document.getElementById('diskValue');
 
@@ -36,6 +46,10 @@ async function fetchTelemetry() {
   if (data.cpu_freq !== null) {
     pushData(cpuFreqChart, data.cpu_freq);
     cpuFreqValue.textContent = data.cpu_freq;
+  }
+  if (data.cpu_usage !== null) {
+    pushData(cpuUsageChart, data.cpu_usage);
+    cpuUsageValue.textContent = data.cpu_usage;
   }
   if (data.mem_used !== null) {
     pushData(memChart, data.mem_used);

--- a/frontend/templates/v2/pi-telemetry.html
+++ b/frontend/templates/v2/pi-telemetry.html
@@ -12,6 +12,10 @@
     <canvas id="cpuFreqChart" height="200"></canvas>
   </div>
   <div class="col-md-6">
+    <h2 class="telemetry-value" id="cpuUsageValue">--</h2>
+    <canvas id="cpuUsageChart" height="200"></canvas>
+  </div>
+  <div class="col-md-6">
     <h2 class="telemetry-value" id="memValue">--</h2>
     <canvas id="memChart" height="200"></canvas>
   </div>


### PR DESCRIPTION
## Summary
- track CPU usage in telemetry service
- show CPU usage on Pi Telemetry page
- plot CPU usage with y-axis locked to 100%

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687febb5febc83209fce1ff23328de20