### PR TITLE
Add startup script and OLED docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@
 
 ```bash
 source backend/venv/bin/activate
-python backend/app.py
-python backend/oled_small.py
+python startup.py
 ```
+
+Для автоматического запуска при загрузке Raspberry Pi скопируйте файл
+`burning-control.service` в `/etc/systemd/system/` и выполните:
+
+```bash
+sudo systemctl enable burning-control.service
+sudo systemctl start burning-control.service
+```
+
+## OLED дисплей
+
+Модуль `oled_small.py` использует дисплей SSD1306 64x48.
+Он подключается к шине I²C (SCL и SDA). Кнопки "влево" и "вправо"
+подключены к выводам D5 и D6 соответственно. Адрес дисплея по умолчанию
+`0x3C`.

--- a/burning-control.service
+++ b/burning-control.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Burning Control
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /path/to/burning-control/startup.py
+WorkingDirectory=/path/to/burning-control
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/startup.py
+++ b/startup.py
@@ -1,0 +1,30 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    root = Path(__file__).resolve().parent / 'backend'
+    python = sys.executable
+    processes = [
+        subprocess.Popen([python, str(root / 'app.py')]),
+        subprocess.Popen([python, str(root / 'oled_small.py')])
+    ]
+    try:
+        for p in processes:
+            p.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        for p in processes:
+            if p.poll() is None:
+                p.terminate()
+        for p in processes:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add startup script to launch API and OLED controller
- provide systemd service for running on boot
- document how to start and document OLED display wiring

## Testing
- `python -m py_compile startup.py`
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688156182c34832083b0925b8f7a8cbf