### PR TITLE
Add voltage control page with INA219 sensor

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request, jsonify, redirect, url_for
 from neopixel_controller import fill, off, set_brightness, run_animation
 from telemetry_service import get_telemetry
+from ina_sensor import read_data as read_ina
 import random
 import time
 
@@ -75,6 +76,10 @@ def led7_strip_page():
 def pi_telemetry():
     return render_template('v2/pi-telemetry.html')
 
+@app.route('/voltage')
+def voltage_control_page():
+    return render_template('v2/voltage.html')
+
 @app.post('/api/color')
 def api_color():
     data = request.get_json()
@@ -110,6 +115,12 @@ def api_status():
 @app.get('/api/telemetry')
 def api_telemetry():
     return jsonify(get_telemetry())
+
+
+@app.get('/api/ina219')
+def api_ina219():
+    data = read_ina()
+    return jsonify(data if data is not None else {})
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=False)

--- a/backend/ina_sensor.py
+++ b/backend/ina_sensor.py
@@ -1,0 +1,45 @@
+import logging
+
+try:
+    import board
+    import busio
+    from adafruit_ina219 import INA219
+except Exception as e:  # pragma: no cover - hardware optional
+    board = busio = INA219 = None
+    logging.error("INA219 libs not available: %s", e)
+
+
+log = logging.getLogger(__name__)
+_sensor = None
+
+def _init_sensor():
+    global _sensor
+    if board is None or busio is None or INA219 is None:
+        return
+    try:
+        i2c = busio.I2C(board.D17, board.D27)
+        _sensor = INA219(i2c)
+        log.info("INA219 initialized")
+    except Exception as e:  # pragma: no cover - hardware error
+        log.warning("INA219 init failed: %s", e)
+        _sensor = None
+
+
+def read_data():
+    """Return INA219 sensor readings if available."""
+    global _sensor
+    if _sensor is None:
+        _init_sensor()
+    if _sensor is None:
+        return None
+    try:
+        return {
+            "bus_voltage": round(_sensor.bus_voltage, 3),
+            "shunt_voltage": round(_sensor.shunt_voltage / 1000, 3),
+            "current": round(_sensor.current, 1),
+            "power": round(_sensor.power, 1),
+        }
+    except Exception as e:  # pragma: no cover - hardware error
+        log.warning("INA219 read failed: %s", e)
+        _sensor = None
+        return None

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.3.*
 rpi_ws281x>=4.3.0
 adafruit-circuitpython-neopixel>=6.3.0
+adafruit-circuitpython-ina219>=1.4.11

--- a/frontend/static/voltage.js
+++ b/frontend/static/voltage.js
@@ -1,0 +1,9 @@
+async function fetchIna() {
+  const resp = await fetch('/api/ina219');
+  const data = await resp.json();
+  const val = data.bus_voltage !== undefined ? data.bus_voltage : '--';
+  document.getElementById('inaV5Value').textContent = val;
+}
+
+fetchIna();
+setInterval(fetchIna, 250);

--- a/frontend/templates/v2/layout.html
+++ b/frontend/templates/v2/layout.html
@@ -22,6 +22,7 @@
         <li class="nav-item"><a class="nav-link" href="/ventilation">Ventilation</a></li>
         <li class="nav-item"><a class="nav-link" href="/monitor">Monitor</a></li>
         <li class="nav-item"><a class="nav-link" href="/led7-strip">LED 7 Strip</a></li>
+        <li class="nav-item"><a class="nav-link" href="/voltage">Voltage Control</a></li>
         <li class="nav-item"><a class="nav-link" href="/pi-telemetry">Pi Telemetry</a></li>
       </ul>
     </div>

--- a/frontend/templates/v2/voltage.html
+++ b/frontend/templates/v2/voltage.html
@@ -1,0 +1,14 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Voltage Control{% endblock %}
+{% block content %}
+<h1 class="mb-4">Voltage Control</h1>
+<div class="card mb-3">
+  <div class="card-header">INA Sensor V5+ Line</div>
+  <div class="card-body">
+    Voltage: <span id="inaV5Value">--</span> V
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='voltage.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add INA219 sensor module for measuring voltage
- expose `/voltage` page and `/api/ina219` endpoint
- create frontend page and JS for live voltage updates
- add navigation link to Voltage Control
- include INA219 dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68825803206c832099bb5f0879490306