### PR TITLE
Support multiple INA sensors

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 from flask import Flask, render_template, request, jsonify, redirect, url_for
 from neopixel_controller import fill, off, set_brightness, run_animation
 from telemetry_service import get_telemetry
-from ina_sensor import read_data as read_ina
+from ina_sensor import read_data as read_ina, read_all as read_all_ina
 from temperature_sensor import read_temperature
 import random
 import time
@@ -117,8 +117,20 @@ def api_telemetry():
 
 @app.get('/api/ina219')
 def api_ina219():
-    data = read_ina()
-    return jsonify(data if data is not None else {})
+    addr_param = request.args.get('addr')
+    if request.args.get('all') is not None:
+        return jsonify(read_all_ina())
+    if addr_param is not None:
+        try:
+            addr = int(addr_param, 0)
+        except ValueError:
+            return jsonify({})
+        data = read_ina(addr)
+    else:
+        data = read_ina()
+    if data is None:
+        return jsonify({"status": "off"})
+    return jsonify({"status": "on", **data})
 
 
 @app.get('/api/temperature')

--- a/backend/ina_sensor.py
+++ b/backend/ina_sensor.py
@@ -1,45 +1,80 @@
+"""INA219 sensor helpers supporting multiple addresses."""
+
 import logging
 
-try:
+try:  # pragma: no cover - hardware optional
     import board
     import busio
     from adafruit_ina219 import INA219
-except Exception as e:  # pragma: no cover - hardware optional
+except Exception as e:  # pragma: no cover - no hardware in tests
     board = busio = INA219 = None
     logging.error("INA219 libs not available: %s", e)
 
 
 log = logging.getLogger(__name__)
-_sensor = None
-
-def _init_sensor():
-    global _sensor
-    if board is None or busio is None or INA219 is None:
-        return
-    try:
-        i2c = busio.I2C(board.SCL, board.SDA)
-        _sensor = INA219(i2c)
-        log.info("INA219 initialized")
-    except Exception as e:  # pragma: no cover - hardware error
-        log.warning("INA219 init failed: %s", e)
-        _sensor = None
 
 
-def read_data():
-    """Return INA219 sensor readings if available."""
-    global _sensor
-    if _sensor is None:
-        _init_sensor()
-    if _sensor is None:
-        return None
-    try:
-        return {
-            "bus_voltage": round(_sensor.bus_voltage, 3),
-            "shunt_voltage": round(_sensor.shunt_voltage / 1000, 3),
-            "current": round(_sensor.current, 1),
-            "power": round(_sensor.power, 1),
-        }
-    except Exception as e:  # pragma: no cover - hardware error
-        log.warning("INA219 read failed: %s", e)
-        _sensor = None
-        return None
+class INASensor:
+    """Wrapper for a single INA219 sensor."""
+
+    def __init__(self, addr: int):
+        self.addr = addr
+        self._sensor = None
+
+    def _init_sensor(self):
+        if board is None or busio is None or INA219 is None:
+            return
+        try:
+            i2c = busio.I2C(board.SCL, board.SDA)
+            self._sensor = INA219(i2c, addr=self.addr)
+            log.info("INA219 0x%02X initialized", self.addr)
+        except Exception as e:  # pragma: no cover - hardware error
+            log.warning("INA219 0x%02X init failed: %s", self.addr, e)
+            self._sensor = None
+
+    def read(self):
+        if self._sensor is None:
+            self._init_sensor()
+        if self._sensor is None:
+            return None
+        try:
+            return {
+                "bus_voltage": round(self._sensor.bus_voltage, 3),
+                "shunt_voltage": round(self._sensor.shunt_voltage / 1000, 3),
+                "current": round(self._sensor.current, 1),
+                "power": round(self._sensor.power, 1),
+            }
+        except Exception as e:  # pragma: no cover - hardware error
+            log.warning("INA219 0x%02X read failed: %s", self.addr, e)
+            self._sensor = None
+            return None
+
+
+_sensors = {}
+DEFAULT_ADDRESSES = [0x40, 0x41, 0x42, 0x43, 0x44, 0x45]
+
+
+def _get_sensor(addr: int) -> INASensor:
+    if addr not in _sensors:
+        _sensors[addr] = INASensor(addr)
+    return _sensors[addr]
+
+
+def read_data(addr: int = 0x40):
+    """Return readings for sensor at given address or ``None``."""
+    return _get_sensor(addr).read()
+
+
+def read_all(addrs=None):
+    """Return readings for a list of sensors with status flags."""
+    if addrs is None:
+        addrs = DEFAULT_ADDRESSES
+    result = {}
+    for addr in addrs:
+        data = read_data(addr)
+        key = f"0x{addr:02X}"
+        if data is None:
+            result[key] = {"status": "off"}
+        else:
+            result[key] = {"status": "on", **data}
+    return result

--- a/frontend/static/voltage.js
+++ b/frontend/static/voltage.js
@@ -1,8 +1,24 @@
+const addresses = [0x40, 0x41, 0x42, 0x43, 0x44, 0x45];
+
 async function fetchIna() {
-  const resp = await fetch('/api/ina219');
-  const data = await resp.json();
-  const val = data.bus_voltage !== undefined ? data.bus_voltage : '--';
-  document.getElementById('inaV5Value').textContent = val;
+  const resp = await fetch('/api/ina219?all=1');
+  const all = await resp.json();
+
+  for (const addr of addresses) {
+    const hex = '0x' + addr.toString(16).toUpperCase();
+    const data = all[hex] || { status: 'off' };
+    const prefix = 'ina_' + hex.slice(2) + '_';
+
+    document.getElementById(prefix + 'bus').textContent =
+      data.bus_voltage !== undefined ? data.bus_voltage : '--';
+    document.getElementById(prefix + 'shunt').textContent =
+      data.shunt_voltage !== undefined ? data.shunt_voltage : '--';
+    document.getElementById(prefix + 'current').textContent =
+      data.current !== undefined ? data.current : '--';
+    document.getElementById(prefix + 'power').textContent =
+      data.power !== undefined ? data.power : '--';
+    document.getElementById(prefix + 'status').textContent = data.status || 'off';
+  }
 }
 
 fetchIna();

--- a/frontend/templates/v2/voltage.html
+++ b/frontend/templates/v2/voltage.html
@@ -2,12 +2,41 @@
 {% block title %}Voltage Control{% endblock %}
 {% block content %}
 <h1 class="mb-4">Voltage Control</h1>
+
 <div class="card mb-3">
   <div class="card-header">INA Sensor V5+ Line</div>
-  <div class="card-body">
-    Voltage: <span id="inaV5Value">--</span> V
-  </div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Bus Voltage: <span id="ina_40_bus">--</span> V</li>
+    <li class="list-group-item">Shunt Voltage: <span id="ina_40_shunt">--</span> V</li>
+    <li class="list-group-item">Current: <span id="ina_40_current">--</span> mA</li>
+    <li class="list-group-item">Power: <span id="ina_40_power">--</span> mW</li>
+    <li class="list-group-item">Status: <span id="ina_40_status">off</span></li>
+  </ul>
 </div>
+
+<div class="card mb-3">
+  <div class="card-header">INA Sensor V3.3+ Line</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Bus Voltage: <span id="ina_41_bus">--</span> V</li>
+    <li class="list-group-item">Shunt Voltage: <span id="ina_41_shunt">--</span> V</li>
+    <li class="list-group-item">Current: <span id="ina_41_current">--</span> mA</li>
+    <li class="list-group-item">Power: <span id="ina_41_power">--</span> mW</li>
+    <li class="list-group-item">Status: <span id="ina_41_status">off</span></li>
+  </ul>
+</div>
+
+{% for addr in ['42','43','44','45'] %}
+<div class="card mb-3">
+  <div class="card-header">INA Sensor 0x{{ addr }}</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Bus Voltage: <span id="ina_{{ addr }}_bus">--</span> V</li>
+    <li class="list-group-item">Shunt Voltage: <span id="ina_{{ addr }}_shunt">--</span> V</li>
+    <li class="list-group-item">Current: <span id="ina_{{ addr }}_current">--</span> mA</li>
+    <li class="list-group-item">Power: <span id="ina_{{ addr }}_power">--</span> mW</li>
+    <li class="list-group-item">Status: <span id="ina_{{ addr }}_status">off</span></li>
+  </ul>
+</div>
+{% endfor %}
 {% endblock %}
 {% block scripts %}
 <script src="{{ url_for('static', filename='voltage.js') }}"></script>


### PR DESCRIPTION
## Summary
- extend INA sensor helper to handle multiple INA219 devices
- expose `addr` and `all` options via `/api/ina219`
- show detailed measurements for each sensor on Voltage Control page
- add frontend script to poll all sensors

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6882894d6a808320b13f433f00e0dc63