### PR TITLE
Add AHT20 sensor support

### DIFF
--- a/backend/aht_sensor.py
+++ b/backend/aht_sensor.py
@@ -1,0 +1,80 @@
+"""Simple helpers for AHT20 temperature/humidity sensors."""
+
+import logging
+
+try:  # pragma: no cover - hardware optional
+    import board
+    import busio
+    import adafruit_ahtx0
+except Exception as e:  # pragma: no cover - no hardware in tests
+    board = busio = adafruit_ahtx0 = None
+    logging.error("AHT20 libs not available: %s", e)
+
+
+log = logging.getLogger(__name__)
+
+
+class AHTSensor:
+    """Wrapper for a single AHT20 sensor."""
+
+    def __init__(self, address: int = 0x38):
+        self.address = address
+        self._sensor = None
+
+    def _init_sensor(self):
+        if board is None or busio is None or adafruit_ahtx0 is None:
+            return
+        try:
+            i2c = busio.I2C(board.SCL, board.SDA)
+            self._sensor = adafruit_ahtx0.AHTx0(i2c, address=self.address)
+            log.info("AHT20 0x%02X initialized", self.address)
+        except Exception as e:  # pragma: no cover - hardware error
+            log.info("AHT20 0x%02X init failed: %s", self.address, e)
+            self._sensor = None
+
+    def read(self):
+        if self._sensor is None:
+            self._init_sensor()
+        if self._sensor is None:
+            return None
+        try:
+            return {
+                "temperature": round(self._sensor.temperature, 1),
+                "humidity": round(self._sensor.relative_humidity, 1),
+            }
+        except Exception as e:  # pragma: no cover - hardware error
+            log.info("AHT20 0x%02X read failed: %s", self.address, e)
+            self._sensor = None
+            return None
+
+
+_sensors = {}
+DEFAULT_ADDRESSES = {1: 0x38, 2: 0x39}
+
+
+def _get_sensor(index: int) -> AHTSensor:
+    addr = DEFAULT_ADDRESSES.get(index, 0x38)
+    if index not in _sensors:
+        _sensors[index] = AHTSensor(addr)
+    return _sensors[index]
+
+
+def read_data(index: int = 1):
+    """Return readings for sensor with given index or ``None``."""
+    return _get_sensor(index).read()
+
+
+def read_all(indices=None):
+    """Return readings for a list of sensors with status flags."""
+    if indices is None:
+        indices = sorted(DEFAULT_ADDRESSES)
+    result = {}
+    for idx in indices:
+        data = read_data(idx)
+        key = str(idx)
+        if data is None:
+            result[key] = {"status": "off"}
+        else:
+            result[key] = {"status": "on", **data}
+    return result
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -3,6 +3,7 @@ from neopixel_controller import fill, off, set_brightness, run_animation
 from telemetry_service import get_telemetry
 from ina_sensor import read_data as read_ina, read_all as read_all_ina
 from temperature_sensor import read_temperature
+from aht_sensor import read_data as read_aht, read_all as read_all_aht
 import random
 import time
 
@@ -139,11 +140,30 @@ def api_temperature():
     return jsonify({'temperature': temp} if temp is not None else {})
 
 
+@app.get('/api/aht20')
+def api_aht20():
+    index_param = request.args.get('idx')
+    if request.args.get('all') is not None:
+        return jsonify(read_all_aht())
+    if index_param is not None:
+        try:
+            idx = int(index_param)
+        except ValueError:
+            return jsonify({})
+        data = read_aht(idx)
+    else:
+        data = read_aht()
+    if data is None:
+        return jsonify({'status': 'off'})
+    return jsonify({'status': 'on', **data})
+
+
 @app.get('/api/sensors')
 def api_sensors():
     return jsonify({
         'ina219': read_ina() or {},
         'temperature': read_temperature(),
+        'aht20': read_all_aht(),
     })
 
 if __name__ == '__main__':

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.3.*
 rpi_ws281x>=4.3.0
 adafruit-circuitpython-neopixel>=6.3.0
 adafruit-circuitpython-ina219>=1.4.11
+adafruit-circuitpython-ahtx0>=2.1.6

--- a/frontend/static/cooling.js
+++ b/frontend/static/cooling.js
@@ -1,0 +1,32 @@
+let interval = 1000;
+let timerId = null;
+
+function startTimer() {
+  if (timerId) clearInterval(timerId);
+  timerId = setInterval(fetchCooling, interval);
+}
+
+document.getElementById('updateInterval')?.addEventListener('change', (e) => {
+  interval = parseInt(e.target.value);
+  startTimer();
+});
+
+async function fetchCooling() {
+  const resp = await fetch('/api/sensors');
+  const data = await resp.json();
+  if (data.aht20) {
+    for (let i = 1; i <= 2; i++) {
+      const val = data.aht20[i];
+      document.getElementById(`aht${i}_temp`).textContent =
+        val && val.temperature !== undefined ? val.temperature : '--';
+      document.getElementById(`aht${i}_hum`).textContent =
+        val && val.humidity !== undefined ? val.humidity : '--';
+      document.getElementById(`aht${i}_status`).textContent =
+        val ? val.status : 'off';
+    }
+  }
+}
+
+fetchCooling();
+startTimer();
+

--- a/frontend/static/sensors.js
+++ b/frontend/static/sensors.js
@@ -1,21 +1,50 @@
+let interval = 1000;
+let timerId = null;
+
+function startTimer() {
+  if (timerId) clearInterval(timerId);
+  timerId = setInterval(fetchSensors, interval);
+}
+
+document.getElementById('updateInterval')?.addEventListener('change', (e) => {
+  interval = parseInt(e.target.value);
+  startTimer();
+});
+
 async function fetchSensors() {
   const resp = await fetch('/api/sensors');
   const data = await resp.json();
+
   if (data.temperature !== undefined && data.temperature !== null) {
     document.getElementById('temperature').textContent = data.temperature;
   }
+
   if (data.ina219) {
     const v = data.ina219;
-    if (v.bus_voltage !== undefined)
-      document.getElementById('bus_voltage').textContent = v.bus_voltage;
-    if (v.shunt_voltage !== undefined)
-      document.getElementById('shunt_voltage').textContent = v.shunt_voltage;
-    if (v.current !== undefined)
-      document.getElementById('current').textContent = v.current;
-    if (v.power !== undefined)
-      document.getElementById('power').textContent = v.power;
+    document.getElementById('bus_voltage').textContent =
+      v.bus_voltage !== undefined ? v.bus_voltage : '--';
+    document.getElementById('shunt_voltage').textContent =
+      v.shunt_voltage !== undefined ? v.shunt_voltage : '--';
+    document.getElementById('current').textContent =
+      v.current !== undefined ? v.current : '--';
+    document.getElementById('power').textContent =
+      v.power !== undefined ? v.power : '--';
+    document.getElementById('ina_status').textContent = v.status || 'off';
+  }
+
+  if (data.aht20) {
+    for (let i = 1; i <= 2; i++) {
+      const val = data.aht20[i];
+      document.getElementById(`aht${i}_temp`).textContent =
+        val && val.temperature !== undefined ? val.temperature : '--';
+      document.getElementById(`aht${i}_hum`).textContent =
+        val && val.humidity !== undefined ? val.humidity : '--';
+      document.getElementById(`aht${i}_status`).textContent =
+        val ? val.status : 'off';
+    }
   }
 }
 
 fetchSensors();
-setInterval(fetchSensors, 250);
+startTimer();
+

--- a/frontend/templates/v2/cooling.html
+++ b/frontend/templates/v2/cooling.html
@@ -1,2 +1,40 @@
-{% extends 'v2/coming_soon.html' %}
+{% extends 'v2/layout.html' %}
 {% block title %}Cooling{% endblock %}
+{% block content %}
+<h1 class="mb-4">Cooling</h1>
+<div class="mb-3">
+  <label for="updateInterval" class="form-label">Update interval</label>
+  <select id="updateInterval" class="form-select w-auto d-inline">
+    <option value="500">0.5s</option>
+    <option value="1000" selected>1s</option>
+    <option value="2000">2s</option>
+    <option value="5000">5s</option>
+  </select>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">AHT20 Sensor 1</div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Temperature: <span id="aht1_temp">--</span> °C</li>
+        <li class="list-group-item">Humidity: <span id="aht1_hum">--</span> %</li>
+        <li class="list-group-item">Status: <span id="aht1_status">off</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">AHT20 Sensor 2</div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Temperature: <span id="aht2_temp">--</span> °C</li>
+        <li class="list-group-item">Humidity: <span id="aht2_hum">--</span> %</li>
+        <li class="list-group-item">Status: <span id="aht2_status">off</span></li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='cooling.js') }}"></script>
+{% endblock %}
+

--- a/frontend/templates/v2/sensors.html
+++ b/frontend/templates/v2/sensors.html
@@ -2,14 +2,55 @@
 {% block title %}Sensors{% endblock %}
 {% block content %}
 <h1 class="mb-4">Sensors</h1>
-<ul class="list-group" id="sensor-data">
-  <li class="list-group-item">Temperature: <span id="temperature">--</span> °C</li>
-  <li class="list-group-item">Bus Voltage: <span id="bus_voltage">--</span> V</li>
-  <li class="list-group-item">Shunt Voltage: <span id="shunt_voltage">--</span> V</li>
-  <li class="list-group-item">Current: <span id="current">--</span> mA</li>
-  <li class="list-group-item">Power: <span id="power">--</span> mW</li>
-</ul>
+<div class="mb-3">
+  <label for="updateInterval" class="form-label">Update interval</label>
+  <select id="updateInterval" class="form-select w-auto d-inline">
+    <option value="500">0.5s</option>
+    <option value="1000" selected>1s</option>
+    <option value="2000">2s</option>
+    <option value="5000">5s</option>
+  </select>
+</div>
+<div class="row">
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">AHT20 Sensor 1</div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Temperature: <span id="aht1_temp">--</span> °C</li>
+        <li class="list-group-item">Humidity: <span id="aht1_hum">--</span> %</li>
+        <li class="list-group-item">Status: <span id="aht1_status">off</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="col-md-6">
+    <div class="card mb-3">
+      <div class="card-header">AHT20 Sensor 2</div>
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item">Temperature: <span id="aht2_temp">--</span> °C</li>
+        <li class="list-group-item">Humidity: <span id="aht2_hum">--</span> %</li>
+        <li class="list-group-item">Status: <span id="aht2_status">off</span></li>
+      </ul>
+    </div>
+  </div>
+</div>
+<div class="card mb-3">
+  <div class="card-header">DS18B20 Sensor</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Temperature: <span id="temperature">--</span> °C</li>
+  </ul>
+</div>
+<div class="card mb-3">
+  <div class="card-header">INA219 Sensor</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Bus Voltage: <span id="bus_voltage">--</span> V</li>
+    <li class="list-group-item">Shunt Voltage: <span id="shunt_voltage">--</span> V</li>
+    <li class="list-group-item">Current: <span id="current">--</span> mA</li>
+    <li class="list-group-item">Power: <span id="power">--</span> mW</li>
+    <li class="list-group-item">Status: <span id="ina_status">off</span></li>
+  </ul>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="{{ url_for('static', filename='sensors.js') }}"></script>
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- add helper to read AHT20 sensors
- wire new API endpoints
- create UI for cooling and sensors pages with two AHT20 sensors
- allow selecting update interval
- add frontend scripts for automatic refresh
- include CircuitPython AHTx0 library in requirements

## Testing
- `python3 -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68828c34022083209c4857a42fbec730