### PR TITLE
Add DHT11 telemetry

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,6 +4,7 @@ from telemetry_service import get_telemetry
 from ina_sensor import read_data as read_ina, read_all as read_all_ina
 from temperature_sensor import read_temperature
 from aht_sensor import read_data as read_aht, read_all as read_all_aht
+from dht_sensor import read_data as read_dht
 import random
 import time
 
@@ -158,12 +159,23 @@ def api_aht20():
     return jsonify({'status': 'on', **data})
 
 
+@app.get('/api/dht11')
+def api_dht11():
+    """Return readings from the DHT11 sensor."""
+    data = read_dht()
+    if data is None:
+        return jsonify({'status': 'off'})
+    return jsonify({'status': 'on', **data})
+
+
 @app.get('/api/sensors')
 def api_sensors():
+    dht = read_dht()
     return jsonify({
         'ina219': read_ina() or {},
         'temperature': read_temperature(),
         'aht20': read_all_aht(),
+        'dht11': {'status': 'on', **dht} if dht else {'status': 'off'},
     })
 
 if __name__ == '__main__':

--- a/backend/dht_sensor.py
+++ b/backend/dht_sensor.py
@@ -1,0 +1,57 @@
+"""DHT11 temperature and humidity sensor helper."""
+
+import logging
+
+try:  # pragma: no cover - hardware optional
+    import board
+    import adafruit_dht
+except Exception as e:  # pragma: no cover - no hardware in tests
+    board = adafruit_dht = None
+    logging.error("DHT11 libs not available: %s", e)
+
+log = logging.getLogger(__name__)
+
+
+class DHT11Sensor:
+    """Wrapper for a single DHT11 sensor."""
+
+    def __init__(self, pin=board.D4):
+        self.pin = pin
+        self._sensor = None
+
+    def _init_sensor(self):
+        if board is None or adafruit_dht is None:
+            return
+        try:
+            self._sensor = adafruit_dht.DHT11(self.pin)
+            log.info("DHT11 on %s initialized", self.pin)
+        except Exception as e:  # pragma: no cover - hardware error
+            log.info("DHT11 init failed: %s", e)
+            self._sensor = None
+
+    def read(self):
+        if self._sensor is None:
+            self._init_sensor()
+        if self._sensor is None:
+            return None
+        try:
+            temp = self._sensor.temperature
+            hum = self._sensor.humidity
+            if temp is None or hum is None:
+                raise RuntimeError("invalid reading")
+            return {
+                "temperature": round(float(temp), 1),
+                "humidity": round(float(hum), 1),
+            }
+        except Exception as e:  # pragma: no cover - hardware error
+            log.info("DHT11 read failed: %s", e)
+            self._sensor = None
+            return None
+
+
+_sensor = DHT11Sensor()
+
+
+def read_data():
+    """Return readings for the DHT11 sensor or ``None``."""
+    return _sensor.read()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ rpi_ws281x>=4.3.0
 adafruit-circuitpython-neopixel>=6.3.0
 adafruit-circuitpython-ina219>=1.4.11
 adafruit-circuitpython-ahtx0>=2.1.6
+adafruit-circuitpython-dht>=3.8.0

--- a/frontend/static/cooling.js
+++ b/frontend/static/cooling.js
@@ -25,6 +25,15 @@ async function fetchCooling() {
         val ? val.status : 'off';
     }
   }
+
+  if (data.dht11) {
+    const v = data.dht11;
+    document.getElementById('dht_temp').textContent =
+      v.temperature !== undefined ? v.temperature : '--';
+    document.getElementById('dht_hum').textContent =
+      v.humidity !== undefined ? v.humidity : '--';
+    document.getElementById('dht_status').textContent = v.status || 'off';
+  }
 }
 
 fetchCooling();

--- a/frontend/static/sensors.js
+++ b/frontend/static/sensors.js
@@ -43,6 +43,15 @@ async function fetchSensors() {
         val ? val.status : 'off';
     }
   }
+
+  if (data.dht11) {
+    const v = data.dht11;
+    document.getElementById('dht_temp').textContent =
+      v.temperature !== undefined ? v.temperature : '--';
+    document.getElementById('dht_hum').textContent =
+      v.humidity !== undefined ? v.humidity : '--';
+    document.getElementById('dht_status').textContent = v.status || 'off';
+  }
 }
 
 fetchSensors();

--- a/frontend/templates/v2/cooling.html
+++ b/frontend/templates/v2/cooling.html
@@ -33,6 +33,14 @@
     </div>
   </div>
 </div>
+<div class="card mb-3">
+  <div class="card-header">DHT11 Sensor</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Temperature: <span id="dht_temp">--</span> °C</li>
+    <li class="list-group-item">Humidity: <span id="dht_hum">--</span> %</li>
+    <li class="list-group-item">Status: <span id="dht_status">off</span></li>
+  </ul>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="{{ url_for('static', filename='cooling.js') }}"></script>

--- a/frontend/templates/v2/sensors.html
+++ b/frontend/templates/v2/sensors.html
@@ -40,6 +40,14 @@
   </ul>
 </div>
 <div class="card mb-3">
+  <div class="card-header">DHT11 Sensor</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Temperature: <span id="dht_temp">--</span> °C</li>
+    <li class="list-group-item">Humidity: <span id="dht_hum">--</span> %</li>
+    <li class="list-group-item">Status: <span id="dht_status">off</span></li>
+  </ul>
+</div>
+<div class="card mb-3">
   <div class="card-header">INA219 Sensor</div>
   <ul class="list-group list-group-flush">
     <li class="list-group-item">Bus Voltage: <span id="bus_voltage">--</span> V</li>


### PR DESCRIPTION
## Summary
- add DHT11 sensor helper and dependencies
- expose `/api/dht11` endpoint and include data in `/api/sensors`
- display DHT11 info on Cooling and Sensors pages
- update frontend scripts for new telemetry

## Testing
- `python -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6888c1403a048320b5060260fb9a7f7e