### PR TITLE
Add Teency telemetry support

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,7 @@ from ina_sensor import read_data as read_ina, read_all as read_all_ina
 from temperature_sensor import read_temperature
 from aht_sensor import read_data as read_aht, read_all as read_all_aht
 from dht_sensor import read_data as read_dht
+from teency_service import start as start_teency, get_data as get_teency_data
 import random
 import time
 
@@ -13,6 +14,9 @@ app = Flask(
     template_folder='../frontend/templates',
     static_folder='../frontend/static'
 )
+
+# start background reader for Teency telemetry
+start_teency()
 
 # Track last generated status to update once per second
 _last_status = {
@@ -70,6 +74,12 @@ def ventilation():
 @app.route('/sensors')
 def sensors():
     return render_template('v2/sensors.html')
+
+
+@app.route('/teency')
+def teency_page():
+    """Display telemetry from the Teency controller."""
+    return render_template('v2/teency.html')
 
 
 @app.route('/pi-telemetry')
@@ -166,6 +176,12 @@ def api_dht11():
     if data is None:
         return jsonify({'status': 'off'})
     return jsonify({'status': 'on', **data})
+
+
+@app.get('/api/teency')
+def api_teency():
+    """Return latest telemetry from the Teency board."""
+    return jsonify(get_teency_data())
 
 
 @app.get('/api/sensors')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ adafruit-circuitpython-neopixel>=6.3.0
 adafruit-circuitpython-ina219>=1.4.11
 adafruit-circuitpython-ahtx0>=1.0.27
 adafruit-circuitpython-dht>=3.8.0
+
+pyserial>=3.5

--- a/backend/teency_service.py
+++ b/backend/teency_service.py
@@ -1,0 +1,70 @@
+import json
+import logging
+import threading
+import time
+from typing import Any, Dict
+
+try:
+    import serial  # type: ignore
+except Exception as e:  # pragma: no cover - optional in tests
+    serial = None
+    logging.error("pyserial not available: %s", e)
+
+log = logging.getLogger(__name__)
+
+_data: Dict[str, Any] = {}
+_serial = None
+_thread_started = False
+
+PORT_CANDIDATES = ["/dev/ttyACM0", "/dev/ttyUSB0"]
+BAUDRATE = 115200
+
+
+def _open_serial():
+    global _serial
+    for port in PORT_CANDIDATES:
+        try:
+            _serial = serial.Serial(port, BAUDRATE, timeout=1)  # type: ignore
+            log.info("Teency connected on %s", port)
+            return
+        except Exception as e:  # pragma: no cover - hardware optional
+            log.info("Teency open %s failed: %s", port, e)
+    _serial = None
+
+
+def _reader():  # pragma: no cover - hardware optional
+    global _data, _serial
+    while True:
+        if serial is None:
+            time.sleep(1)
+            continue
+        if _serial is None:
+            _open_serial()
+            time.sleep(1)
+            continue
+        try:
+            line = _serial.readline().decode("utf-8", errors="ignore").strip()
+            if not line:
+                continue
+            _data = json.loads(line)
+        except Exception as e:
+            log.warning("Teency read failed: %s", e)
+            try:
+                _serial.close()
+            except Exception:
+                pass
+            _serial = None
+            time.sleep(1)
+
+
+def start():
+    global _thread_started
+    if _thread_started:
+        return
+    _thread_started = True
+    t = threading.Thread(target=_reader, daemon=True)
+    t.start()
+
+
+def get_data() -> Dict[str, Any]:
+    return _data

--- a/frontend/static/teency.js
+++ b/frontend/static/teency.js
@@ -1,0 +1,38 @@
+let interval = 500;
+let timerId = null;
+
+function startTimer() {
+  if (timerId) clearInterval(timerId);
+  timerId = setInterval(fetchTeency, interval);
+}
+
+document.getElementById('updateInterval')?.addEventListener('change', (e) => {
+  interval = parseInt(e.target.value);
+  startTimer();
+});
+
+async function fetchTeency() {
+  const resp = await fetch('/api/teency');
+  const data = await resp.json();
+  if (data.ts !== undefined) {
+    document.getElementById('ts').textContent = data.ts;
+  }
+  if (data.U !== undefined) {
+    document.getElementById('voltage').textContent = data.U;
+  }
+  if (data.I !== undefined) {
+    document.getElementById('current').textContent = data.I;
+  }
+  if (data.P !== undefined) {
+    document.getElementById('power').textContent = data.P;
+  }
+  if (Array.isArray(data.R)) {
+    document.getElementById('relays').textContent = data.R.join(', ');
+  }
+  if (data.B !== undefined) {
+    document.getElementById('button').textContent = data.B;
+  }
+}
+
+fetchTeency();
+startTimer();

--- a/frontend/templates/v2/layout.html
+++ b/frontend/templates/v2/layout.html
@@ -22,6 +22,7 @@
         <li class="nav-item"><a class="nav-link" href="/ventilation">Ventilation</a></li>
         <li class="nav-item"><a class="nav-link" href="/sensors">Sensors</a></li>
         <li class="nav-item"><a class="nav-link" href="/voltage">Voltage Control</a></li>
+        <li class="nav-item"><a class="nav-link" href="/teency">Teency</a></li>
         <li class="nav-item"><a class="nav-link" href="/pi-telemetry">Pi Telemetry</a></li>
       </ul>
     </div>

--- a/frontend/templates/v2/teency.html
+++ b/frontend/templates/v2/teency.html
@@ -1,0 +1,27 @@
+{% extends 'v2/layout.html' %}
+{% block title %}Teency{% endblock %}
+{% block content %}
+<h1 class="mb-4">Teency Telemetry</h1>
+<div class="mb-3">
+  <label for="updateInterval" class="form-label">Update interval</label>
+  <select id="updateInterval" class="form-select w-auto d-inline">
+    <option value="100">0.1s</option>
+    <option value="500" selected>0.5s</option>
+    <option value="1000">1s</option>
+  </select>
+</div>
+<div class="card mb-3">
+  <div class="card-header">Telemetry Data</div>
+  <ul class="list-group list-group-flush">
+    <li class="list-group-item">Timestamp: <span id="ts">--</span></li>
+    <li class="list-group-item">Voltage: <span id="voltage">--</span> V</li>
+    <li class="list-group-item">Current: <span id="current">--</span> A</li>
+    <li class="list-group-item">Power: <span id="power">--</span> W</li>
+    <li class="list-group-item">Relays: <span id="relays">--</span></li>
+    <li class="list-group-item">Button: <span id="button">--</span></li>
+  </ul>
+</div>
+{% endblock %}
+{% block scripts %}
+<script src="{{ url_for('static', filename='teency.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `teency_service` for reading serial JSON data from the Teency controller
- create `/teency` page and show telemetry with adjustable update interval
- expose `/api/teency` endpoint
- link Teency page in navbar
- include pyserial in backend requirements

## Testing
- `python3 -m py_compile backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68891bbad7f48320ba33d8e23b9cab65