### PR TITLE
Fix JSON property quoting in Arduino code

### DIFF
--- a/firmware/0_Main/0_Main.ino
+++ b/firmware/0_Main/0_Main.ino
@@ -15,7 +15,9 @@ void setup() {
 }
 
 static void printVoltageSensor(const char *name, const VoltageSensorData &s, bool last=false) {
-  Serial.print('"'); Serial.print(name); Serial.print("":{");
+  Serial.print('"');
+  Serial.print(name);
+  Serial.print("\":{");
   Serial.print("\"current\":"); Serial.print(s.isAvailable ? s.current : 0, 3);
   Serial.print(",\"voltage\":"); Serial.print(s.isAvailable ? s.voltage : 0, 3);
   Serial.print(",\"power\":"); Serial.print(s.isAvailable ? s.power : 0, 3);
@@ -25,7 +27,9 @@ static void printVoltageSensor(const char *name, const VoltageSensorData &s, boo
 }
 
 static void printTempSensor(const char *name, const TemperatureSensorData &s, bool last=false) {
-  Serial.print('"'); Serial.print(name); Serial.print("":{");
+  Serial.print('"');
+  Serial.print(name);
+  Serial.print("\":{");
   Serial.print("\"temperature\":"); Serial.print(s.isAvailable ? s.temperature : 0, 1);
   Serial.print(",\"humidity\":"); Serial.print(s.isAvailable ? s.humidity : 0, 1);
   Serial.print(",\"isAvailable\":"); Serial.print(s.isAvailable ? "true" : "false");


### PR DESCRIPTION
## Summary
- fix quoting in the Arduino helpers so JSON prints correctly

## Testing
- `python3 -m compileall -q backend`

------
https://chatgpt.com/codex/tasks/task_e_688927f5e7248320b20d85a8138777f2