### PR TITLE
Fix AHT sensor begin parameters

### DIFF
--- a/firmware/0_Main/Sensors.ino
+++ b/firmware/0_Main/Sensors.ino
@@ -56,8 +56,9 @@ void initSensors() {
   sensorV3.begin();
   sensorV5.begin();
   sensorV24.begin();
-  aht1_ok = aht1.begin(0x38);
-  aht2_ok = aht2.begin(0x39);
+  // pass explicit Wire instance and sensor ID to avoid implicit int conversion
+  aht1_ok = aht1.begin(&Wire, -1, 0x38);
+  aht2_ok = aht2.begin(&Wire, -1, 0x39);
 }
 
 void pollSensors() {


### PR DESCRIPTION
## Summary
- use explicit Wire instance and sensor ID when initializing AHT sensors

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688929113dec8320bb9f4387ea158dab