### PR TITLE
Fetch Teensy data via API for OLED

### DIFF
--- a/backend/oled_small.py
+++ b/backend/oled_small.py
@@ -13,7 +13,27 @@ except Exception as e:  # pragma: no cover - hardware optional
     logging.error("Required hardware libraries not available: %s", e)
 
 from telemetry_service import get_telemetry
-from teency_service import get_data as get_teency_data
+from teency_service import (
+    DEFAULT_DATA,
+    get_data as get_teency_data,
+)
+try:
+    import requests  # type: ignore
+except Exception:
+    requests = None
+
+
+def fetch_teency() -> dict:
+    """Get telemetry from the Flask API if available."""
+    if requests is None:
+        return get_teency_data()
+    try:
+        resp = requests.get("http://localhost:5000/api/teency", timeout=0.5)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+    return DEFAULT_DATA.copy()
 
 
 log = logging.getLogger(__name__)
@@ -126,7 +146,7 @@ class OLEDApp:
     def render_home(self):
         data = get_telemetry()
         cpu = data.get('cpu_usage')
-        teency = get_teency_data()
+        teency = fetch_teency()
         vs_pibrain = teency.get('voltageSensorV5PiBrain', {})
         volt_5 = vs_pibrain.get('voltage', 0.0)
         amp_5 = vs_pibrain.get('current', 0.0)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ adafruit-circuitpython-ahtx0>=1.0.27
 adafruit-circuitpython-dht>=3.8.0
 
 pyserial>=3.5
+requests>=2.31


### PR DESCRIPTION
## Summary
- avoid opening the Teensy serial port in multiple processes
- fetch telemetry for the OLED display from Flask API instead
- include `requests` dependency

## Testing
- `python -m py_compile backend/oled_small.py`


------
https://chatgpt.com/codex/tasks/task_e_688a5a1166b48320b926010c4c1f0b87