### PR TITLE
Fix relative imports in backend package

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,10 +1,10 @@
 from flask import Flask, render_template, request, jsonify, redirect, url_for
-from neopixel_controller import fill, off, set_brightness, run_animation
-from telemetry_service import get_telemetry
-from temperature_sensor import read_temperature
-from aht_sensor import read_data as read_aht, read_all as read_all_aht
-from dht_sensor import read_data as read_dht
-from teency_service import start as start_teency, get_data as get_teency_data
+from .neopixel_controller import fill, off, set_brightness, run_animation
+from .telemetry_service import get_telemetry
+from .temperature_sensor import read_temperature
+from .aht_sensor import read_data as read_aht, read_all as read_all_aht
+from .dht_sensor import read_data as read_dht
+from .teency_service import start as start_teency, get_data as get_teency_data
 import random
 import time
 import json

--- a/backend/oled_small.py
+++ b/backend/oled_small.py
@@ -12,8 +12,8 @@ except Exception as e:  # pragma: no cover - hardware optional
     Image = ImageDraw = ImageFont = adafruit_ssd1306 = None
     logging.error("Required hardware libraries not available: %s", e)
 
-from telemetry_service import get_telemetry
-from teency_service import (
+from .telemetry_service import get_telemetry
+from .teency_service import (
     DEFAULT_DATA,
     get_data as get_teency_data,
 )


### PR DESCRIPTION
## Summary
- use relative imports for backend modules so package imports work

## Testing
- `pytest -q`
- `python3 -m py_compile main.py backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_688bb62d83a48320b0548aa880484a32