### PR TITLE
Refactor UART handling and worker setup

### DIFF
--- a/backend/logger.py
+++ b/backend/logger.py
@@ -1,22 +1,16 @@
-import json
-import logging
-import queue
+import json, logging, queue
 from logging.handlers import RotatingFileHandler
 
-
 def run(q):
-    """Log telemetry packets from the central queue."""
-    logging.basicConfig(level=logging.INFO)
-    log = logging.getLogger(__name__)
-    handler = RotatingFileHandler("telemetry.log", maxBytes=1_000_000, backupCount=5)
-    log.addHandler(handler)
-    log.setLevel(logging.INFO)
+    log = logging.getLogger("logger")
+    fh  = RotatingFileHandler("telemetry.log", maxBytes=1_000_000, backupCount=5)
+    fh.setFormatter(logging.Formatter("%(message)s"))
+    log.addHandler(fh); log.setLevel(logging.INFO)
     while True:
         try:
-            pkt = q.get(timeout=0.2)
-            if isinstance(pkt, dict) and pkt.get("type") == "telemetry":
+            pkt = q.get(timeout=1)
+            if pkt.get("type") == "telemetry":
                 log.info(json.dumps(pkt))
         except queue.Empty:
             continue
-        except KeyboardInterrupt:
-            break
+

--- a/backend/teensy_reader.py
+++ b/backend/teensy_reader.py
@@ -1,0 +1,34 @@
+import json, logging, time, queue
+try:
+    import serial
+except ImportError:
+    serial = None
+
+PORTS   = ["/dev/ttyACM0", "/dev/ttyUSB0"]
+BAUD    = 115200
+LOG     = logging.getLogger("reader")
+
+def _open():
+    for p in PORTS:
+        try: return serial.Serial(p, BAUD, timeout=1)
+        except Exception: LOG.info("no %s", p)
+    return None
+
+def run(q):
+    ser = None
+    while True:
+        if serial is None: time.sleep(1); continue
+        if ser is None: ser = _open(); time.sleep(1); continue
+
+        try:
+            line = ser.readline().decode("utf-8","ignore").strip()
+            if not line: continue
+            pkt  = {"type":"telemetry", **json.loads(line)}
+            try: q.put_nowait(pkt)
+            except queue.Full: LOG.warning("drop pkt")
+        except Exception as e:
+            LOG.warning("reset serial %s", e)
+            try: ser.close()
+            except Exception: pass
+            ser = None
+


### PR DESCRIPTION
## Summary
- centralize process orchestration in `main.py`
- add new `backend.teensy_reader` as single serial reader
- connect Flask to queue without UART access
- simplify OLED and logger entrypoints

## Testing
- `python -m py_compile main.py backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688bc1e3802483208d8364c156d00e47