### PR TITLE
Fix Teency availability status

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -23,7 +23,9 @@ def _listener(q):
             continue
 
 def get_teency_data():        # used by /api/teency etc.
-    return _teency or {"status":"wait"}
+    if _teency:
+        return {**_teency, "status": _teency.get("status", "ok")}
+    return {"status": "wait"}
 
 app = Flask(
     __name__,


### PR DESCRIPTION
## Summary
- Ensure `/api/teency` includes a status field so the Teency page reports the board as available

## Testing
- `python -m py_compile backend/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e24035934832086171028739ffbe6