### PR TITLE
Use AHT20 only on address 0x38

### DIFF
--- a/backend/aht_sensor.py
+++ b/backend/aht_sensor.py
@@ -49,7 +49,10 @@ class AHTSensor:
 
 
 _sensors = {}
-DEFAULT_ADDRESSES = {1: 0x38, 2: 0x39}
+# Only one AHT20 sensor is used by default and it is fixed at address 0x38.
+# A second sensor on 0x39 was previously supported but caused issues when only
+# a single device is present and its address cannot be changed.
+DEFAULT_ADDRESSES = {1: 0x38}
 
 
 def _get_sensor(index: int) -> AHTSensor:

--- a/backend/app.py
+++ b/backend/app.py
@@ -165,7 +165,7 @@ def _teency_aht(idx: int):
 def api_aht20():
     index_param = request.args.get('idx')
     if request.args.get('all') is not None:
-        return jsonify({str(i): _teency_aht(i) for i in (1, 2)})
+        return jsonify({"1": _teency_aht(1)})
     if index_param is not None:
         try:
             idx = int(index_param)
@@ -197,7 +197,7 @@ def api_sensors():
     return jsonify({
         'teency': get_teency_data(),
         'temperature': read_temperature(),
-        'aht20': {str(i): _teency_aht(i) for i in (1, 2)},
+        'aht20': {'1': _teency_aht(1)},
         'dht11': {'status': 'on', **dht} if dht else {'status': 'off'},
     })
 

--- a/firmware/0_Main/0_Main.ino
+++ b/firmware/0_Main/0_Main.ino
@@ -45,8 +45,7 @@ void sendJson() {
   printVoltageSensor("voltageSensorV5", data.voltageSensorV5);
   printVoltageSensor("voltageSensorV5PiBrain", data.voltageSensorV5PiBrain);
   printVoltageSensor("voltageSensorV24", data.voltageSensorV24);
-  printTempSensor("temperatureSensor1", data.temperatureSensor1);
-  printTempSensor("temperatureSensor2", data.temperatureSensor2, true);
+  printTempSensor("temperatureSensor1", data.temperatureSensor1, true);
   Serial.print('}');
   Serial.print('\n');
 }

--- a/firmware/0_Main/Sensors.ino
+++ b/firmware/0_Main/Sensors.ino
@@ -16,13 +16,10 @@ static bool v5pb_ok = false;
 static bool v24_ok = false;
 
 Adafruit_AHTX0 aht1; // address 0x38
-Adafruit_AHTX0 aht2; // address 0x39
 
 static bool aht1_ok = false;
-static bool aht2_ok = false;
 
 static constexpr uint8_t ADDR_AHT1 = 0x38;
-static constexpr uint8_t ADDR_AHT2 = 0x39;
 static bool checkInaAlive(uint8_t addr) {
   Wire.beginTransmission(addr);
   return Wire.endTransmission() == 0;
@@ -136,7 +133,6 @@ void initSensors() {
   v24_ok = startIna(sensorV24);
   // pass explicit Wire instance and sensor ID to avoid implicit int conversion
   aht1_ok = startAht(aht1, ADDR_AHT1);
-  aht2_ok = startAht(aht2, ADDR_AHT2);
 }
 
 void pollSensors() {
@@ -146,7 +142,6 @@ void pollSensors() {
   readIna(sensorV5PiBrain, ADDR_V5PB, v5pb_ok, data.voltageSensorV5PiBrain);
   readIna(sensorV24, ADDR_V24, v24_ok, data.voltageSensorV24);
   readAHT(aht1, ADDR_AHT1, aht1_ok, data.temperatureSensor1);
-  readAHT(aht2, ADDR_AHT2, aht2_ok, data.temperatureSensor2);
   data.button = buttonPressed();
   data.relay1 = digitalRead(PIN_RELAY1);
   data.relay2 = digitalRead(PIN_RELAY2);


### PR DESCRIPTION
## Summary
- update default AHT sensor address mapping
- expose only one AHT sensor via API
- remove second AHT sensor from firmware

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688ceaac0644832092aed3fc16622d7f