### PR TITLE
Route logs to files with timestamps

### DIFF
--- a/backend/logger.py
+++ b/backend/logger.py
@@ -4,7 +4,7 @@ from logging.handlers import RotatingFileHandler
 def run(q):
     log = logging.getLogger("logger")
     fh  = RotatingFileHandler("telemetry.log", maxBytes=1_000_000, backupCount=5)
-    fh.setFormatter(logging.Formatter("%(message)s"))
+    fh.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
     log.addHandler(fh); log.setLevel(logging.INFO)
     while True:
         try:

--- a/backend/oled_small.py
+++ b/backend/oled_small.py
@@ -1,6 +1,7 @@
 ﻿# backend/oled_small.py — минимальный вывод пяти параметров на маленький OLED
 
 import logging
+from logging.handlers import RotatingFileHandler
 import threading
 import time
 import queue
@@ -120,7 +121,6 @@ def _listener(q):
 
 def run(q):
     """Вызывается orchestrator'ом main.py"""
-    logging.basicConfig(level=logging.INFO)
     threading.Thread(target=_listener, args=(q,), daemon=True).start()
     OLED().loop()
 
@@ -128,6 +128,11 @@ def run(q):
 def main():
     """Standalone запуск на ПК/PI без очереди."""
     from multiprocessing import Queue
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+        handlers=[RotatingFileHandler("system.log", maxBytes=1_000_000, backupCount=5)],
+    )
     run(Queue())
 
 

--- a/backend/webapp.py
+++ b/backend/webapp.py
@@ -1,9 +1,7 @@
-import logging
 from .app import app
 
 
 def run(q):
     """Start the Flask web application."""
-    logging.basicConfig(level=logging.INFO)
     # The queue is unused but kept for a consistent interface
     app.run(host="0.0.0.0", port=5000, debug=False)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import importlib, logging, time
 from multiprocessing import Process, Queue
+from logging.handlers import RotatingFileHandler
 
 workers = {
     # single UART reader
@@ -12,7 +13,12 @@ workers = {
 }
 
 def main():
-    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+    handler = RotatingFileHandler("system.log", maxBytes=1_000_000, backupCount=5)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s: %(message)s",
+        handlers=[handler],
+    )
     q = Queue(maxsize=200)
     procs = []
     for name, mp in workers.items():


### PR DESCRIPTION
## Summary
- route application logs to rotating file with timestamps
- timestamp telemetry log entries
- unify module logging by removing per-module basicConfig

## Testing
- `python -m pytest`
- `python -m py_compile main.py backend/logger.py backend/webapp.py backend/oled_small.py`


------
https://chatgpt.com/codex/tasks/task_e_688f195bd9b88320b0c79cb73fcdfd3b